### PR TITLE
This commit refactors the application to improve security and robustn…

### DIFF
--- a/ai_processing.py
+++ b/ai_processing.py
@@ -5,15 +5,17 @@ import logging
 # Настройка логгирования
 logger = logging.getLogger(__name__)
 
-# Получаем ключ из переменных окружения
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "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")
+# Получаем ключ из переменных окружения, который должен быть установлен при запуске основного скрипта.
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
 async def _call_openrouter(system_prompt: str, user_prompt: str) -> str:
     """
     Универсальная функция для вызова API OpenRouter.
     """
     if not OPENROUTER_API_KEY:
-        raise ValueError("Не найден ключ для OpenRouter.")
+        # Эта проверка на случай, если модуль используется отдельно.
+        # Основной скрипт уже проверяет наличие ключа при старте.
+        raise ValueError("Ключ OpenRouter API не найден в переменных окружения.")
 
     headers = {
         "Authorization": f"Bearer {OPENROUTER_API_KEY}",

--- a/telegram_openrouter_bot.py
+++ b/telegram_openrouter_bot.py
@@ -16,15 +16,16 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # --- Ключи API ---
-# ВАЖНО: При развертывании проекта на сервере (Render и т.д.)
-# эти ключи нужно устанавливать как переменные окружения, а не хранить в коде.
-TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "7563880680:AAFpM3h7QXmOVtKdWv5aGYDj-J_C61JXp9o")
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "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")
+# Ключи должны быть установлены как переменные окружения перед запуском.
+# Инструкцию по запуску я предоставлю после завершения всех изменений.
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
+# Проверяем, что ключи установлены. Если нет - бот не запустится.
 if not TELEGRAM_BOT_TOKEN:
-    raise ValueError("Не найден токен для Telegram. Установите переменную окружения TELEGRAM_BOT_TOKEN.")
+    raise ValueError("Переменная окружения TELEGRAM_BOT_TOKEN не установлена! Бот не может запуститься.")
 if not OPENROUTER_API_KEY:
-    raise ValueError("Не найден ключ для OpenRouter. Установите переменную окружения OPENROUTER_API_KEY.")
+    raise ValueError("Переменная окружения OPENROUTER_API_KEY не установлена! Бот не может запуститься.")
 
 
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
…ess by removing hardcoded default API tokens.

- Both `telegram_openrouter_bot.py` and `ai_processing.py` now fetch keys using `os.getenv()` without a default value.
- The main script now raises a clear `ValueError` at startup if the necessary environment variables (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) are not set.

This change prevents the bot from running with invalid default tokens and forces the user to provide valid credentials at runtime, which should resolve the persistent `InvalidToken` errors and make the application easier to configure and deploy correctly.